### PR TITLE
Limits on filesize and duration - issue #148

### DIFF
--- a/src/safm/settings/common.py
+++ b/src/safm/settings/common.py
@@ -150,11 +150,17 @@ DJANGO_REST_MULTITOKENAUTH_RESET_TOKEN_EXPIRY_TIME = 2 # in hours
 CLIENT_APP_URL = os.environ.get('CLIENT_APP_URL', 'localhost:3000')
 
 
+# file upload limit settings
 # nginx limit is 50mb
 NGINX_FILE_UPLOAD_LIMIT = 50 * (1<<20)
-MAX_FILE_UPLOAD_SIZE = NGINX_FILE_UPLOAD_LIMIT-(500*(1<<10))
+# 5mb less than nginx so an error can be displayed through application
+MAX_FILE_UPLOAD_SIZE = NGINX_FILE_UPLOAD_LIMIT-(5<<20)
 max_file_size = os.environ.get("MAX_FILE_SIZE")
 if max_file_size:
     MAX_FILE_UPLOAD_SIZE = min(
         MAX_FILE_UPLOAD_SIZE, int(os.environ.get("MAX_FILE_SIZE"))
     )
+
+
+# audio file duration limit settings
+MAX_AUDIO_DURATION = float(os.environ.get("MAX_AUDIO_DURATION", "30"))

--- a/src/safm/settings/common.py
+++ b/src/safm/settings/common.py
@@ -150,17 +150,20 @@ DJANGO_REST_MULTITOKENAUTH_RESET_TOKEN_EXPIRY_TIME = 2 # in hours
 CLIENT_APP_URL = os.environ.get('CLIENT_APP_URL', 'localhost:3000')
 
 
-# file upload limit settings
-# nginx limit is 50mb
-NGINX_FILE_UPLOAD_LIMIT = 50 * (1<<20)
-# 5mb less than nginx so an error can be displayed through application
-MAX_FILE_UPLOAD_SIZE = NGINX_FILE_UPLOAD_LIMIT-(5<<20)
-max_file_size = os.environ.get("MAX_FILE_SIZE")
-if max_file_size:
+# file upload limit settings in bytes :- (1<<20) is 1mb
+
+WEBSERVER_FILE_UPLOAD_LIMIT = 50*(1<<20)
+
+MAX_FILE_UPLOAD_SIZE = 10*(1<<20)
+_max_file_size = os.environ.get("MAX_FILE_SIZE")
+if _max_file_size:
+    # always less than webserver's limit so an error
+    # can be displayed through application server
     MAX_FILE_UPLOAD_SIZE = min(
-        MAX_FILE_UPLOAD_SIZE, int(os.environ.get("MAX_FILE_SIZE"))
+        WEBSERVER_FILE_UPLOAD_LIMIT - (5*(1<<20)),
+        int(_max_file_size)
     )
 
 
-# audio file duration limit settings
+# audio file duration limit settings in seconds
 MAX_AUDIO_DURATION = float(os.environ.get("MAX_AUDIO_DURATION", "30"))

--- a/src/safm/settings/common.py
+++ b/src/safm/settings/common.py
@@ -146,7 +146,7 @@ CLIENT_APP_URL = os.environ.get('CLIENT_APP_URL', 'localhost:3000')
 WEBSERVER_FILE_UPLOAD_LIMIT = 50*(1<<20)
 
 MAX_FILE_UPLOAD_SIZE = 10*(1<<20)
-_max_file_size = os.environ.get("MAX_FILE_SIZE")
+_max_file_size = os.environ.get('MAX_FILE_SIZE')
 if _max_file_size:
     # always less than webserver's limit so an error
     # can be displayed through application server
@@ -157,4 +157,4 @@ if _max_file_size:
 
 
 # audio file duration limit settings in seconds
-MAX_AUDIO_DURATION = float(os.environ.get("MAX_AUDIO_DURATION", "30"))
+MAX_AUDIO_DURATION = float(os.environ.get('MAX_AUDIO_DURATION', '30'))

--- a/src/safm/settings/common.py
+++ b/src/safm/settings/common.py
@@ -47,7 +47,7 @@ REST_FRAMEWORK = {
 MIDDLEWARE = [
     # Added
     'corsheaders.middleware.CorsMiddleware',
-    
+
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -106,6 +106,15 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+<<<<<<< HEAD
+=======
+# Password reset
+
+DJANGO_REST_MULTITOKENAUTH_RESET_TOKEN_EXPIRY_TIME = 2 # in hours
+
+CLIENT_APP_URL = os.environ.get('CLIENT_APP_URL', 'localhost:3000')
+
+>>>>>>> 1d75754... safm: add file size validator and settings for max file size
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.0/topics/i18n/
@@ -137,5 +146,15 @@ DEFAULT_PROFILE_PICTURE = 'default/pictures/pp.png'
 
 # Password reset
 
-DJANGO_REST_MULTITOKENAUTH_RESET_TOKEN_EXPIRY_TIME = 2 # in hours 
+DJANGO_REST_MULTITOKENAUTH_RESET_TOKEN_EXPIRY_TIME = 2 # in hours
 CLIENT_APP_URL = os.environ.get('CLIENT_APP_URL', 'localhost:3000')
+
+
+# nginx limit is 50mb
+NGINX_FILE_UPLOAD_LIMIT = 50 * (1<<20)
+MAX_FILE_UPLOAD_SIZE = NGINX_FILE_UPLOAD_LIMIT-(500*(1<<10))
+max_file_size = os.environ.get("MAX_FILE_SIZE")
+if max_file_size:
+    MAX_FILE_UPLOAD_SIZE = min(
+        MAX_FILE_UPLOAD_SIZE, int(os.environ.get("MAX_FILE_SIZE"))
+    )

--- a/src/safm/settings/common.py
+++ b/src/safm/settings/common.py
@@ -106,15 +106,6 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-<<<<<<< HEAD
-=======
-# Password reset
-
-DJANGO_REST_MULTITOKENAUTH_RESET_TOKEN_EXPIRY_TIME = 2 # in hours
-
-CLIENT_APP_URL = os.environ.get('CLIENT_APP_URL', 'localhost:3000')
-
->>>>>>> 1d75754... safm: add file size validator and settings for max file size
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.0/topics/i18n/

--- a/src/safm_api/serializers.py
+++ b/src/safm_api/serializers.py
@@ -6,7 +6,7 @@ from django.contrib.auth.hashers import check_password
 from .models import Tag, Sample, UserProfile, UserSampleDownload, SampleLike
 
 from .utils import get_safe_file_name
-from .validators import FileSizeValidator
+from .validators import FileSizeValidator, AudioFileDurationValidator
 
 class UserSerializer(serializers.ModelSerializer):
     email = serializers.EmailField(write_only=True, validators=[UniqueValidator(queryset=User.objects.all())])
@@ -101,7 +101,9 @@ class TagSerializer(serializers.ModelSerializer):
 
 
 class SampleForkSerializer(serializers.ModelSerializer):
-    file = serializers.FileField(validators=[FileSizeValidator()])
+    file = serializers.FileField(validators=[
+        FileSizeValidator(), AudioFileDurationValidator(),
+    ])
     class Meta:
         model = Sample
         fields = '__all__'
@@ -119,11 +121,12 @@ class SampleSerializer(serializers.ModelSerializer):
     user = UserSerializer(read_only=True)
     tags = TagSerializer(many=True, required=False)
     forks = SampleForkSerializer(write_only=True, many=True, required=False)
-    file = serializers.FileField(validators=[FileSizeValidator()])
+    file = serializers.FileField(validators=[
+        FileSizeValidator(), AudioFileDurationValidator(),
+    ])
 
     def create(self, validated_data):
         sample = Sample.objects.create(**validated_data)
-
         # Automatically deducted properties
         sample.deduce_properties()
         sample.save()

--- a/src/safm_api/utils.py
+++ b/src/safm_api/utils.py
@@ -1,6 +1,7 @@
 from django.utils.text import slugify
 
-def get_safe_file_name(filename):
+
+def get_safe_file_name(filename: str):
     '''
     Return a safe file name that has only ascii chars
     '''

--- a/src/safm_api/validators.py
+++ b/src/safm_api/validators.py
@@ -1,0 +1,25 @@
+from django.conf import settings
+from rest_framework.serializers import ValidationError
+
+
+class FileSizeValidator:
+    '''
+    Validate file size is less than provided value
+    Applicable to serializers.FileField
+    '''
+    def __init__(self, max_size: int=settings.MAX_FILE_UPLOAD_SIZE):
+        '''
+        Params:
+        ---------
+            max_size:
+                max file size in bytes
+        '''
+        self.max_size = max_size
+
+    def __call__(self, value: int):
+        if value.size > self.max_size:
+            raise ValidationError(
+                'Please upload a file size <= {0:.2f}MB'.format(
+                    self.max_size/(1<<20)
+                )
+            )

--- a/src/safm_api/validators.py
+++ b/src/safm_api/validators.py
@@ -48,7 +48,6 @@ class AudioFileDurationValidator:
                 tmp_file.write(chunk)
 
             duration = af.duration(tmp_file.name)
-            print(f"Duration is {duration:.2f}")
             if duration > self.max_duration:
                 raise ValidationError(
                     'Please upload a sample <= {0:.1f}s'.format(

--- a/src/safm_api/validators.py
+++ b/src/safm_api/validators.py
@@ -1,3 +1,6 @@
+import tempfile
+
+import audiofile as af
 from django.conf import settings
 from rest_framework.serializers import ValidationError
 
@@ -11,15 +14,44 @@ class FileSizeValidator:
         '''
         Params:
         ---------
-            max_size:
-                max file size in bytes
+            max_size:  max file size in bytes
         '''
         self.max_size = max_size
 
-    def __call__(self, value: int):
+    def __call__(self, value):
         if value.size > self.max_size:
             raise ValidationError(
-                'Please upload a file size <= {0:.2f}MB'.format(
+                'Please upload a file with size <= {0:.2f}MB'.format(
                     self.max_size/(1<<20)
                 )
             )
+
+class AudioFileDurationValidator:
+    '''
+    Validate audio file duration to be less than provided value
+    Applicable to audio files
+    '''
+
+    def __init__(self, max_duration: float=settings.MAX_AUDIO_DURATION):
+        '''
+        Params:
+        --------
+            max_duration: max duration in seconds
+        '''
+        self.max_duration = max_duration
+
+    def __call__(self, value):
+        # in order for duration to be calculated, file must be
+        # temporarily written to disk
+        with tempfile.NamedTemporaryFile() as tmp_file:
+            for chunk in value.chunks():
+                tmp_file.write(chunk)
+
+            duration = af.duration(tmp_file.name)
+            print(f"Duration is {duration:.2f}")
+            if duration > self.max_duration:
+                raise ValidationError(
+                    'Please upload a sample <= {0:.1f}s'.format(
+                        self.max_duration
+                    )
+                )


### PR DESCRIPTION
This is for issue #148  : Add custom validators to restrict file size and duration. Some type hints also added. 
Bonus: Added missing validate_file function in SampleSerializer.