### PR TITLE
#167 add python linter and pre-commit hooks

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -33,7 +33,7 @@ jobs:
       # run python linter on changed files
       run: |
         pre-commit install
-        git remote add upstream git@github.com:HE-Arc/social-audio-free-market.git && git fetch upstream master
+        pwd && git status && git fetch
         FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r $GITHUB_SHA upstream/${{ github.base_ref }})
         echo Running linter on: $FILES_CHANGED
         pre-commit run --files $FILES_CHANGED

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -33,7 +33,7 @@ jobs:
       # run python linter on changed files
       run: |
         pre-commit install
-        pre-commit run --files $(git diff --diff-filter=d --name-only master)
+        pre-commit run --files $(git diff-tree --no-commit-id --name-only -r ${{ github.sha }})
     - name: Shutdown Ubuntu MySQL
       run: sudo service mysql stop # Shutdown the Default MySQL, "sudo" is necessary
     - name: Setup MySQL

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -29,6 +29,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+    - name: Python Linter Check
+      # run python linter on changed files
+      run: |
+        pre-commit install
+        pre-commit run --files $(git diff --diff-filter=d --name-only master)
     - name: Shutdown Ubuntu MySQL
       run: sudo service mysql stop # Shutdown the Default MySQL, "sudo" is necessary
     - name: Setup MySQL

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -33,7 +33,8 @@ jobs:
       # run python linter on changed files
       run: |
         pre-commit install
-        FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r $GITHUB_SHA master)
+        echo Diff on $GITHUB_SHA from ${{ github.base_ref }}
+        FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r $GITHUB_SHA ${{ github.base_ref }})
         echo Running linter on: $FILES_CHANGED
         pre-commit run --files $FILES_CHANGED
     - name: Shutdown Ubuntu MySQL

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -33,7 +33,7 @@ jobs:
       # run python linter on changed files
       run: |
         pre-commit install
-        git remote add upstream git@github.com:HE-Arc/social-audio-free-market.git
+        git remote add upstream git@github.com:HE-Arc/social-audio-free-market.git && git fetch upstream master
         FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r $GITHUB_SHA upstream/${{ github.base_ref }})
         echo Running linter on: $FILES_CHANGED
         pre-commit run --files $FILES_CHANGED

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -33,7 +33,9 @@ jobs:
       # run python linter on changed files
       run: |
         pre-commit install
-        pre-commit run --files $(git diff-tree --no-commit-id --name-only -r)
+        FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r $GITHUB_SHA master)
+        echo Running linter on: $FILES_CHANGED
+        pre-commit run --files $FILES_CHANGED
     - name: Shutdown Ubuntu MySQL
       run: sudo service mysql stop # Shutdown the Default MySQL, "sudo" is necessary
     - name: Setup MySQL

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -33,7 +33,7 @@ jobs:
       # run python linter on changed files
       run: |
         pre-commit install
-        pre-commit run --files $(git diff-tree --no-commit-id --name-only -r ${{ github.sha }})
+        pre-commit run --files $(git diff-tree --no-commit-id --name-only -r)
     - name: Shutdown Ubuntu MySQL
       run: sudo service mysql stop # Shutdown the Default MySQL, "sudo" is necessary
     - name: Setup MySQL

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -33,8 +33,8 @@ jobs:
       # run python linter on changed files
       run: |
         pre-commit install
-        echo Diff on $GITHUB_SHA from ${{ github.base_ref }}
-        FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r $GITHUB_SHA ${{ github.base_ref }})
+        git remote add upstream git@github.com:HE-Arc/social-audio-free-market.git
+        FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r $GITHUB_SHA upstream/${{ github.base_ref }})
         echo Running linter on: $FILES_CHANGED
         pre-commit run --files $FILES_CHANGED
     - name: Shutdown Ubuntu MySQL

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -33,8 +33,8 @@ jobs:
       # run python linter on changed files
       run: |
         pre-commit install
-        pwd && git status && git fetch
-        FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r $GITHUB_SHA upstream/${{ github.base_ref }})
+        git fetch
+        FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r $GITHUB_SHA ${{ github.base_ref }})
         echo Running linter on: $FILES_CHANGED
         pre-commit run --files $FILES_CHANGED
     - name: Shutdown Ubuntu MySQL

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         pre-commit install
         git fetch
-        FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r $GITHUB_SHA ${{ github.base_ref }})
+        FILES_CHANGED=$(git diff-tree --no-commit-id --name-only -r $GITHUB_SHA origin/${{ github.base_ref }})
         echo Running linter on: $FILES_CHANGED
         pre-commit run --files $FILES_CHANGED
     - name: Shutdown Ubuntu MySQL

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,6 @@ repos:
     rev: 3.8.4
     hooks:
         -   id: flake8
+    # flake8 is notorious for being overly strict at times
+    # to ignore some violations check here for use case
+    # https://flake8.pycqa.org/en/latest/user/violations.html#ignoring-violations-with-flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+# TODO: If you make any changes to this file, checkout
+
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+        -   id: trailing-whitespace
+        -   id: end-of-file-fixer
+        -   id: check-yaml
+        -   id: check-added-large-files
+
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4
+    hooks:
+        -   id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         -   id: end-of-file-fixer
         -   id: check-yaml
         -   id: check-added-large-files
-
+# python linter and pep8 convention conformer
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.4
     hooks:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Then, install the dependencies :
 pip install -r requirements.txt
 ```
 
+Install pre-commit hooks:
+
+```
+pre-commit install
+```
+
 At last, apply the migrations and run the server :
 
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ Markdown==3.2.1
 mysqlclient==1.4.6
 numba==0.49.1
 numpy==1.18.4
+pre-commit>=2.7.1
 pycparser==2.20
 pytz==2019.3
 resampy==0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ Markdown==3.2.1
 mysqlclient==1.4.6
 numba==0.49.1
 numpy==1.18.4
-pre-commit>=2.7.1
+pre-commit==2.7.1
 pycparser==2.20
 pytz==2019.3
 resampy==0.2.2


### PR DESCRIPTION
For #167 
Add python linter and pre-commit hook to project. Benefits: All code will be statically checked on every commit on the developers system so that reviewers can focus on the good stuff.

Side Note: (Also added to pre-commit-config.yaml) flake8 can be overly strict maintainers might have to monitor for a bit and take a call on what kind of errors can be permanently ignored by the linter for the repo.